### PR TITLE
Fix bug with DateTime in kept_criteria_as_json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 0.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix bug with DateTime in kept_criteria_as_json.
+  [cedricmessiant]
 
 
 0.5 (2016-05-13)

--- a/src/collective/eeafaceted/collectionwidget/testing/default_collection.xml
+++ b/src/collective/eeafaceted/collectionwidget/testing/default_collection.xml
@@ -63,5 +63,16 @@
    <property name="sortreversed">0</property>
    <property name="default"/>
   </criterion>
+  <criterion name="c4">
+   <property name="widget">daterange</property>
+   <property name="title">Creation date</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">0</property>
+   <property name="index">created</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+   <property name="usePloneDateFormat">0</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/collective/eeafaceted/collectionwidget/tests/test_vocabulary.py
+++ b/src/collective/eeafaceted/collectionwidget/tests/test_vocabulary.py
@@ -169,13 +169,13 @@ class TestVocabulary(IntegrationTestCase):
         sortingCriterionId = ICriteria(self.folder).add('sorting', 'bottom', **data)
         vocabulary = CollectionVocabularyFactory(self.folder.subfolder)
         self.assertEquals(vocabulary.getTermByToken(c1.UID()).title[1],
-                          '{0}?no_redirect=1#c1={1}&c4=effective&reversed=on'.format(self.folder.absolute_url(),
+                          '{0}?no_redirect=1#c1={1}&c5=effective&reversed=on'.format(self.folder.absolute_url(),
                                                                                      c1.UID()))
         data = {'default': u'effective'}
         ICriteria(self.folder).edit(sortingCriterionId, **data)
         vocabulary = CollectionVocabularyFactory(self.folder.subfolder)
         self.assertEquals(vocabulary.getTermByToken(c1.UID()).title[1],
-                          '{0}?no_redirect=1#c1={1}&c4=effective'.format(self.folder.absolute_url(),
+                          '{0}?no_redirect=1#c1={1}&c5=effective'.format(self.folder.absolute_url(),
                                                                          c1.UID()))
 
         # test that other default values are kept also, add a 'resultsperpage' widget
@@ -183,5 +183,5 @@ class TestVocabulary(IntegrationTestCase):
         ICriteria(self.folder).add('resultsperpage', 'bottom', **data)
         vocabulary = CollectionVocabularyFactory(self.folder.subfolder)
         self.assertEquals(vocabulary.getTermByToken(c1.UID()).title[1],
-                          '{0}?no_redirect=1#c1={1}&c4=effective&c5=20'.format(self.folder.absolute_url(),
+                          '{0}?no_redirect=1#c1={1}&c5=effective&c6=20'.format(self.folder.absolute_url(),
                                                                                c1.UID()))

--- a/src/collective/eeafaceted/collectionwidget/tests/test_widget.py
+++ b/src/collective/eeafaceted/collectionwidget/tests/test_widget.py
@@ -6,6 +6,7 @@ from zope.component import getGlobalSiteManager
 from zope.component import getMultiAdapter
 from zope.interface import Interface
 from plone import api
+from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 
 from collective.eeafaceted.collectionwidget.testing.testcase import IntegrationTestCase
@@ -184,12 +185,12 @@ class TestWidget(BaseWidgetCase):
 
         # test case where value is a DateTime
         collection1.query = [
-            {'i': 'created', 'o': 'plone.app.querystring.operation.date.lessThan', 'v': '01/01/2000'},
+            {'i': 'created', 'o': 'plone.app.querystring.operation.date.lessThan', 'v': DateTime(2000, 1, 1)},
         ]
         kept_criteria_as_json = widget.kept_criteria_as_json(collection1.UID())
         self.assertEquals(
             json._default_decoder.decode(kept_criteria_as_json)['c4'],
-            [u'01/01/2000']
+            u'2000-01-01T00:00:00+01:00'
         )
 
     def test_default(self):

--- a/src/collective/eeafaceted/collectionwidget/tests/test_widget.py
+++ b/src/collective/eeafaceted/collectionwidget/tests/test_widget.py
@@ -189,8 +189,8 @@ class TestWidget(BaseWidgetCase):
         ]
         kept_criteria_as_json = widget.kept_criteria_as_json(collection1.UID())
         self.assertEquals(
-            json._default_decoder.decode(kept_criteria_as_json)['c4'],
-            u'2000-01-01T00:00:00+01:00'
+            json._default_decoder.decode(kept_criteria_as_json)['c4'][:10],
+            u'2000-01-01'
         )
 
     def test_default(self):

--- a/src/collective/eeafaceted/collectionwidget/widgets/view.js
+++ b/src/collective/eeafaceted/collectionwidget/widgets/view.js
@@ -120,8 +120,8 @@ clearCriteria = function(tag) {
 
 /* only show advanced criteria that are not managed by selected collection */
 showRelevantAdvancedCriteria = function(tag) {
-  keptCriteria = jQuery(tag).data()['keptCriteria']
-  advancedCriteria = jQuery(tag).parent().data()['advancedCriteria']
+  keptCriteria = jQuery(tag).data('kept-criteria');
+  advancedCriteria = jQuery(tag).parent().data('advanced-criteria')
   /* disable checkboxes base on kept criteria */
   $.each(keptCriteria, function(criterion_id, enabled_checkboxes) {
     var available_checkboxes = $('#'+criterion_id+'_widget input');

--- a/src/collective/eeafaceted/collectionwidget/widgets/widget.py
+++ b/src/collective/eeafaceted/collectionwidget/widgets/widget.py
@@ -8,6 +8,7 @@ from collective.eeafaceted.collectionwidget.interfaces import IWidgetDefaultValu
 from plone.app.querystring import queryparser
 from plone.memoize.view import memoize
 from Acquisition import aq_parent
+from DateTime import DateTime
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
@@ -149,6 +150,11 @@ class CollectionWidget(RadioWidget):
         adapter = queryMultiAdapter((self.context, self),
                                     IKeptCriteria)
         res = adapter.compute(collection_uid)
+        # DateTime are not json serializable, we convert them before
+        for k, v in res.iteritems():
+            if isinstance(v, DateTime):
+                res[k] = v.ISO()
+
         return json.dumps(res)
 
     @property


### PR DESCRIPTION
`DateTime` are not json serializable so `kept_criteria_as_json` breaks if one of the values is a date, we have to convert dates to strings before `json.dumps`.
(I didn't found where `kept-criteria` is used, maybe a deserialization is necessary)