### PR TITLE
Fix an issue with the widget used in combination with collective.solr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix an issue with the widget used in combination with collective.solr
+  [mpeeters]
 
 
 1.6 (2019-01-03)

--- a/src/collective/eeafaceted/collectionwidget/widgets/widget.py
+++ b/src/collective/eeafaceted/collectionwidget/widgets/widget.py
@@ -30,6 +30,7 @@ class CollectionWidget(RadioWidget):
 
     widget_type = 'collection-link'
     widget_label = 'Collection Link'
+    faceted_field = False
 
     index = ViewPageTemplateFile('widget.pt')
 


### PR DESCRIPTION
This avoid filling the facet.field with an empty index that breaks queries with collective.solr