### PR TITLE
Added parameter RenderTermView.compute_count_on_init, True by default…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Added parameter RenderTermView.compute_count_on_init, True by default that
+  will do the collections count be computed when the widget is rendered. This
+  makes it possible to disable it.
+  [gbastien]
 
 1.6 (2019-01-03)
 ----------------

--- a/src/collective/eeafaceted/collectionwidget/browser/templates/term.pt
+++ b/src/collective/eeafaceted/collectionwidget/browser/templates/term.pt
@@ -18,7 +18,7 @@
                   tal:attributes="href python: not redirect_to and 'javascript:;;' or redirect_to">
                   <span class="term-label" tal:content="term_label" />
                   <span tal:condition="view/display_number_of_items">
-                     [<span class="term-count" tal:content="view/number_of_items" />]
+                     [<span class="term-count" tal:content="python: view.number_of_items(init=True)" />]
                   </span>
               </a>
           </li>

--- a/src/collective/eeafaceted/collectionwidget/browser/views.py
+++ b/src/collective/eeafaceted/collectionwidget/browser/views.py
@@ -30,15 +30,20 @@ class RenderCategoryView(BrowserView):
 
 class RenderTermView(BrowserView):
 
+    compute_count_on_init = True
+
     def display_number_of_items(self):
         """Display number of items in the collection."""
         if not IDashboardCollection.providedBy(self.context):
             return True
         return self.context.showNumberOfItems
 
-    def number_of_items(self):
+    def number_of_items(self, init=False):
         """Return the number of items in the collection."""
-        return len(self.context.results())
+        if init and not self.compute_count_on_init:
+            return "..."
+        else:
+            return len(self.context.results())
 
     def __call__(self, term, category, widget):
         self.term = term

--- a/src/collective/eeafaceted/collectionwidget/widgets/widget.pt
+++ b/src/collective/eeafaceted/collectionwidget/widgets/widget.pt
@@ -45,7 +45,7 @@
             <tal:renderCategory condition="category"
                 replace="structure python: category_term.value.restrictedTraverse('@@render_collection_widget_category')(widget=view)" />
             <tal:items repeat="term collection_terms">
-              <tal:renderTerm replace="structure python: term.value.restrictedTraverse('@@render_collection_widget_term')(term, category, widget=view)" />
+              <tal:renderTerm replace="structure python: term.value.unrestrictedTraverse('@@render_collection_widget_term')(term, category, widget=view)" />
             </tal:items>
           </div>
       </tal:category>


### PR DESCRIPTION
… that will do the collections count be computed when the widget is rendered. This makes it possible to disable it.